### PR TITLE
feat: isolate MCP tool cache per HTTP session

### DIFF
--- a/packages/mcp/src/tools/sf-enable-tools.ts
+++ b/packages/mcp/src/tools/sf-enable-tools.ts
@@ -16,7 +16,8 @@
 
 import { z } from 'zod';
 import { McpTool, McpToolConfig, ReleaseState, Toolset } from '@salesforce/mcp-provider-api';
-import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { CallToolResult, ServerNotification, ServerRequest } from '@modelcontextprotocol/sdk/types.js';
+import { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol.js';
 import { enableTools as utilEnableTools } from '../utils/tools.js';
 import { SfMcpServer } from '../sf-mcp-server.js';
 
@@ -63,7 +64,10 @@ Once you have enabled the tool, you MUST invoke that tool to accomplish the user
     };
   }
 
-  public async exec(input: InputArgs): Promise<CallToolResult> {
+  public async exec(
+    input: InputArgs,
+    extra: RequestHandlerExtra<ServerRequest, ServerNotification>
+  ): Promise<CallToolResult> {
     if (input.tools.length === 0) {
       return {
         isError: true,
@@ -76,7 +80,7 @@ Once you have enabled the tool, you MUST invoke that tool to accomplish the user
       };
     }
 
-    const results = await utilEnableTools(input.tools);
+    const results = await utilEnableTools(input.tools, extra.sessionId);
 
     this.server.sendToolListChanged();
 

--- a/packages/mcp/src/tools/sf-list-tools.ts
+++ b/packages/mcp/src/tools/sf-list-tools.ts
@@ -15,7 +15,8 @@
  */
 
 import { McpTool, McpToolConfig, ReleaseState, Toolset } from '@salesforce/mcp-provider-api';
-import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { CallToolResult, ServerNotification, ServerRequest } from '@modelcontextprotocol/sdk/types.js';
+import { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol.js';
 import { listAllTools } from '../utils/tools.js';
 
 export class ListToolsMcpTool extends McpTool {
@@ -55,13 +56,15 @@ Once a tool has been enabled, you do not need to call sf-list-tools again - inst
     };
   }
 
-  public async exec(): Promise<CallToolResult> {
+  public async exec(
+    extra: RequestHandlerExtra<ServerRequest, ServerNotification>
+  ): Promise<CallToolResult> {
     return {
       isError: false,
       content: [
         {
           type: 'text',
-          text: JSON.stringify(await listAllTools(), null, 2),
+          text: JSON.stringify(await listAllTools(extra.sessionId), null, 2),
         },
       ],
     };


### PR DESCRIPTION
## Summary
- scope the shared tool cache by session and add helpers to reset or dispose individual session entries
- plumb session identifiers through tool registration and lifecycle hooks so HTTP sessions start with a clean tool list
- update MCP tools and unit tests to exercise the new per-session behaviour

## Testing
- `TS_NODE_TRANSPILE_ONLY=1 NODE_OPTIONS='--loader ts-node/esm' ../../node_modules/.bin/mocha "test/unit/tools.test.ts"`

------
https://chatgpt.com/codex/tasks/task_b_68ca0c66bcf08329b4d5de17c11f8f8a